### PR TITLE
Decouple anomaly id from instance_id

### DIFF
--- a/rpackage/bohemia/R/app.R
+++ b/rpackage/bohemia/R/app.R
@@ -3553,7 +3553,7 @@ save(rf, file = '/tmp/rf.RData')
                                    done = FALSE,
                                    done_by = ' ')
     }
-    joined <- dplyr::left_join(action, corrections %>% dplyr::mutate(id = paste0(resolution_category, '_', instance_id))) %>%
+    joined <- dplyr::left_join(action, corrections %>% dplyr::mutate(anomaly_reference_key = paste0(resolution_category, '_', instance_id))) %>%
       # dplyr::filter(!done)
       dplyr::select(-done, -done_by)
 

--- a/scripts/bohemia_db_schema.sql
+++ b/scripts/bohemia_db_schema.sql
@@ -926,3 +926,9 @@ ALTER TABLE anomalies ADD CONSTRAINT fk_corrections FOREIGN KEY (correction_id) 
 ALTER TABLE corrections
     ADD COLUMN instance_id TEXT NOT NULL,
     ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+-- Anomalies make id independent of instance_id
+
+ALTER TABLE anomalies ADD COLUMN anomaly_reference_key TEXT;
+UPDATE anomalies SET anomaly_reference_key = id WHERE anomaly_reference_key IS NULL;
+ALTER TABLE anomalies ALTER COLUMN anomaly_reference_key SET NOT NULL;


### PR DESCRIPTION
**What PR does**
- Add a new column `anomaly_reference_key` to the `anomalies` table
- Adds the query to migrate the existing `id` values to the `anomaly_reference_key`
- Adds the constraint to the `anomaly_reference_key` to always be populated